### PR TITLE
Updated model of Service object according to Specification

### DIFF
--- a/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/DDO.java
+++ b/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/DDO.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import jp.co.soramitsu.sora.sdk.did.validation.ISO8601DateTimeFormatter;
 import jp.co.soramitsu.sora.sdk.did.validation.ISO8601NormalizedDateTime;
 import lombok.AllArgsConstructor;
@@ -39,6 +41,7 @@ public class DDO {
 
   @JsonProperty("service")
   @Singular("service")
+  @Valid
   private List<Service> service;
 
   @JsonProperty("guardian")
@@ -46,7 +49,7 @@ public class DDO {
 
   @JsonProperty("created")
   @ISO8601NormalizedDateTime
-  @NonNull
+  @NotNull
   private String created;
 
   @JsonProperty("updated")

--- a/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/Service.java
+++ b/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/Service.java
@@ -1,26 +1,43 @@
 package jp.co.soramitsu.sora.sdk.did.model.dto;
 
-import static com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS;
 import static java.util.Arrays.stream;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import jp.co.soramitsu.sora.sdk.did.model.Executable;
+import jp.co.soramitsu.sora.sdk.did.model.dto.service.GenericService;
 import jp.co.soramitsu.sora.sdk.did.model.dto.service.ServiceExecutor;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NonNull;
 
-@JsonTypeInfo(use = CLASS, property = "type")
+@JsonDeserialize(as = GenericService.class)
 @Data
-@AllArgsConstructor
 public abstract class Service implements Executable<ServiceExecutor> {
 
-  @NonNull
-  DID id;
+  @NotNull
+  private String type;
 
-  @NonNull
-  URL serviceEndpoint;
+  @NotEmpty
+  private List<URL> serviceEndpoint;
+
+  private Map<String, Object> details;
+
+  public Service(String type, @NotEmpty URL ...serviceEndpoint) {
+    this.serviceEndpoint = new ArrayList<>(Arrays.asList(serviceEndpoint));
+    this.type = type;
+  }
+
+  public String getType() {
+    if (type == null) {
+      type = getClass().getCanonicalName();
+    }
+    return type;
+  }
 
   @Override
   public final void execute(ServiceExecutor serviceExecutor) {

--- a/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/service/GenericService.java
+++ b/src/main/java/jp/co/soramitsu/sora/sdk/did/model/dto/service/GenericService.java
@@ -3,15 +3,16 @@ package jp.co.soramitsu.sora.sdk.did.model.dto.service;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.net.URL;
-import jp.co.soramitsu.sora.sdk.did.model.dto.DID;
 import jp.co.soramitsu.sora.sdk.did.model.dto.Service;
+import lombok.experimental.Accessors;
 
+@Accessors(chain = true)
 public class GenericService extends Service {
 
   @JsonCreator
   public GenericService(
-      @JsonProperty("id") DID serviceId,
-      @JsonProperty("serviceEndpoint") URL endpointURL) {
-    super(serviceId, endpointURL);
+      @JsonProperty("type") String type,
+      @JsonProperty("serviceEndpoint") URL ... endpointURL) {
+    super(type, endpointURL);
   }
 }

--- a/src/test/groovy/jp/co/soramitsu/sora/sdk/dto/DDOTest.groovy
+++ b/src/test/groovy/jp/co/soramitsu/sora/sdk/dto/DDOTest.groovy
@@ -19,6 +19,8 @@ import javax.validation.Validation
 import javax.xml.bind.DatatypeConverter
 import java.time.Instant
 
+import static java.util.Collections.singletonMap
+
 class DDOTest extends Specification {
 
     final def PATH_TO_JSON =  "/json/ddo/canonical-1.json"
@@ -50,7 +52,7 @@ class DDOTest extends Specification {
                 .id(owner)
                 .publicKey(new Ed25519Sha3VerificationKey(pubkeyId, null, [48] as byte[]))
                 .authentication(new Ed25519Sha3Authentication(pubkeyId))
-                .service(new GenericService(owner.withFragment("service-1"), new URL("https://google.com/")))
+                .service(new GenericService(null, new URL("https://google.com/")))
                 .created(created)
                 .updated(updated)
                 .build()
@@ -80,11 +82,13 @@ class DDOTest extends Specification {
         def engine = new Ed25519Sha3()
         def keyPair = engine.generateKeypair(privKeySeed)
 
+        def service = new GenericService(null, new URL("https://google.com/"))
+        service.setDetails(singletonMap("id", owner.withFragment("service-1")))
         DDO ddo = DDO.builder()
                 .id(owner)
                 .publicKey(new Ed25519Sha3VerificationKey(pubkeyId, null, keyPair.getPublic().getEncoded()))
                 .authentication(new Ed25519Sha3Authentication(pubkeyId))
-                .service(new GenericService(owner.withFragment("service-1"), new URL("https://google.com/")))
+                .service(service)
                 .created(created)
                 .updated(updated)
                 .build()

--- a/src/test/resources/json/ddo/canonical-1.json
+++ b/src/test/resources/json/ddo/canonical-1.json
@@ -20,6 +20,15 @@
       "publicKey": "did:sora:uuid:caab4570-5f3f-4050-8d61-15306dea4bcf#keys-1"
     }
   ],
+  "service":[{
+    "type":"jp.co.soramitsu.sora.bcaunitbackend.services.SharingRulesService",
+    "serviceEndpoint": ["https://example.com/"],
+    "details" : {
+      "id" : "did:sora:uuid:fakeuuid#service-1",
+      "owner" : "Alice",
+      "bla" : "blabla"
+    }
+  }],
   "created": "2018-07-04T17:00:00Z",
   "proof": {
     "type": "Ed25519Sha3Signature",


### PR DESCRIPTION
Updated model of Service object according to Specification https://github.com/soramitsu/sora-specs/blob/master/did-spec.md OBP-3

1. All custom Services are deserialized to GenericService
2. If custom service has additional properties they can be put in map "details"
3. Property "id" moved to "details" because of it is not described in specification
4. Property "serviceEndpoint" can be plural

Example
```
{
...
"service":[{
    "type":"foo.bar.zulu.CustomService",
    "serviceEndpoint":"[https://example.com/]"
    "details" : {
	"id" : "did:sora:uuid:2abdb374-3feb-49cf-a819-5b80622cb750#service-1"
        "owner" : "Alice",
        ...
    }
  }]
...
}
```